### PR TITLE
Bugfix - Empty simulated deleted files

### DIFF
--- a/ExportManager.js
+++ b/ExportManager.js
@@ -594,7 +594,7 @@ class ExportManager
                         if (this.simulateDeletedPct && this.since) {
                             let cnt = Math.round(count/100 * this.simulateDeletedPct);
                             
-                            deletedArr.push({
+                            cnt && deletedArr.push({
                                 type: row.fhir_type,
                                 count: cnt,
                                 url: lib.buildUrlPath(

--- a/tests/bulk_data.test.js
+++ b/tests/bulk_data.test.js
@@ -124,6 +124,7 @@ class Client
      * @param {object}   [options.headers = {}]
      * @param {boolean}  [options.secure = false]
      * @param {string}   [options.fileError]
+     * @param {number}   [options.del]
      */
     async kickOff(options = {})
     {
@@ -134,7 +135,8 @@ class Client
             err     : options.simulatedError || "",
             extended: !!options.extended,
             secure  : !!options.secure,
-            fileError: options.fileError
+            fileError: options.fileError,
+            del: options.del
         };
 
         if (options.resourcesPerFile) {
@@ -1591,6 +1593,19 @@ describe("File Downloading", function() {
                 await lib.requestPromise({ url });
             }
         }
+    });
+
+    it("Retrieval of referenced files on an open endpoint with deletions", async () => {
+        const client = new Client();
+        await client.kickOff({ _type: "Device", _since: "2010-01-01T12:00:00Z", del: 10 });
+        const status = await client.checkStatus();
+
+        const deleted = status.body.deleted
+        assert(Array.isArray(deleted))
+
+        await Promise.all(
+            deleted.map(file => client.downloadFile(file.url))
+        )
     });
     
     it("Retrieval of referenced files on protected endpoint", async () => {


### PR DESCRIPTION
When using the [fhir downloader](https://github.com/smart-on-fhir/sample-apps-stu3/tree/master/fhir-downloader) sample app, downloading a simulated deletion fails due to a 500 error when attempting to download the file of deleted `Device` resources.

For instance, a request like: `"https://bulk-data.smarthealthit.org/eyJpZCI6IjUzNmE0YzU0NGQ2Mzg4YTgyM2FmYjViMGQyYTRkNTliIiwibGltaXQiOjAsImRlbCI6MSwib2Zmc2V0IjowfQ/fhir/bulkfiles/1.Device.ndjson"`, whose sim deserializes to `{"id":"536a4c544d6388a823afb5b0d2a4d59b","limit":0,"del":1,"offset":0}`. It appears this happens because there 0 devices in the deleted collection, the server status check returns a url for a file which does not exist, and then the server throws a 500 when attempting to get that file.

This PR reproduces the error in a test in the first commit, which is fixed by the second commit. This seems relatively straightforward, however I am not familiar with this codebase so wouldn't know of any special side effects. This PR does NOT fix the downstream defect of a 500 being returned instead of a 404.

Note the following tests are failing on master (and here). 

```sh
 1) Error responses
       token endpoint
         returns 400 invalid_grant if no public keys can be found:
     Error:  The error response should equal:
{
  "error": "invalid_grant",
  "error_description": "No public keys found in the JWKS with \"kid\" equal to \"61a57bcf052664411ad6cab60524a840\" and \"kty\" equal to \"EC\""
}
 but was:
{
  "error": "invalid_grant",
  "error_description": "No public keys found in the JWKS with \"kid\" equal to \"61a57bcf052664411ad6cab60524a840\""
}
      at /Users/jlbch/repos/smart-on-fhir/bulk-data-server/tests/bulk_data.test.js:345:1093
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)

  2) Error responses
       token endpoint
         returns 400 invalid_grant if none of the public keys can decrypt the token:
     Error:  The error response should equal:
{
  "error": "invalid_grant",
  "error_description": "Unable to verify the token with any of the public keys found in the JWKS"
}
 but was:
{
  "error": "invalid_grant",
  "error_description": "Unable to verify the token with any of the public keys found in the JWKS: invalid signature"
}
      at /Users/jlbch/repos/smart-on-fhir/bulk-data-server/tests/bulk_data.test.js:345:1093
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)

  3) BulkData Import
       Import status endpoint
         Replies with 200 JSON and Expires header on completed import:
     Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/jlbch/repos/smart-on-fhir/bulk-data-server/tests/import.test.js)
      at listOnTimeout (internal/timers.js:554:17)
      at processTimers (internal/timers.js:497:7)

  4) BulkData Import
       Import status endpoint
         Reports errors in the error array:
     Error: Too Many Requests
      at Request._callback (tests/lib.js:8:596)
      at Request.self.callback (node_modules/request/request.js:185:22)
      at Request.<anonymous> (node_modules/request/request.js:1154:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1076:12)
      at endReadableNT (_stream_readable.js:1223:12)
      at processTicksAndRejections (internal/process/task_queues.js:84:21)
```
