### PR TITLE
metadata: fix profile to be string, not dict

### DIFF
--- a/fhir/metadata.ts
+++ b/fhir/metadata.ts
@@ -97,9 +97,9 @@ class CapabilityStatement
             },
             {
                 "type": "OperationDefinition",
-                "profile": {
-                    "reference": "http://hl7.org/fhir/Profile/OperationDefinition"
-                },
+                "profile": this.stu === 4 ?
+                    "http://hl7.org/fhir/Profile/OperationDefinition" :
+                    { "reference": "http://hl7.org/fhir/Profile/OperationDefinition" },
                 "interaction": [
                     {
                         "code": "read"
@@ -155,7 +155,7 @@ class CapabilityStatement
                 "description": "SMART Sample Bulk Data Server"
             },
             fhirVersion: getFhirVersion(this.stu),
-            acceptUnknown: "extensions",
+            ...(this.stu < 4 && {acceptUnknown: "extensions"}),
             format: [ "json" ],
             rest: [
                 {


### PR DESCRIPTION
Per the FHIR spec, it is defined as a canonical URL (string, right?):
https://www.hl7.org/fhir/capabilitystatement.html

And in fhirclient, it is validated as a string:
https://github.com/smart-on-fhir/client-py/blob/b4da2bdc3bf024b6d0a78c85d80bf513302c1b13/fhirclient/models/capabilitystatement.py#L516

And remove non-spec parameter `acceptUnknown`.

The current dictionary definition makes it impossible to use fhirclient to inspect server metadata because you'll get an error like:
```
models.fhirabstractbase.FHIRValidationError: {root}:
  rest.0:
    resource.2:
      profile:
        Wrong type <class 'dict'> for property "profile" on <class 'models.capabilitystatement.CapabilityStatementRestResource'>, expecting <class 'str'>
  Superfluous entry "acceptUnknown" in data for <models.capabilitystatement.CapabilityStatement object at 0x7f93f0226350>
```